### PR TITLE
Export/Import Functionality

### DIFF
--- a/snap/bin/export
+++ b/snap/bin/export
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+EXPORT_PATH="$SNAP_COMMON/export-$(date +%Y%m%d-%H%M%S).tar.gz"
+SOURCE_PATHS="$SNAP_COMMON/var $SNAP_COMMON/conf"
+
+echo "Exporting from: $SOURCE_PATHS"
+echo "Saving to: $EXPORT_PATH"
+
+tar -czf "$EXPORT_PATH" $SOURCE_PATHS
+
+echo "Export complete: $EXPORT_PATH"

--- a/snap/bin/export
+++ b/snap/bin/export
@@ -2,11 +2,11 @@
 set -e
 
 EXPORT_PATH="$SNAP_COMMON/export-$(date +%Y%m%d-%H%M%S).tar.gz"
-SOURCE_PATHS="$SNAP_COMMON/var $SNAP_COMMON/conf"
 
 echo "Exporting from: $SOURCE_PATHS"
 echo "Saving to: $EXPORT_PATH"
 
-tar -czf "$EXPORT_PATH" $SOURCE_PATHS
+cd "$SNAP_COMMON"
+tar -czf "$EXPORT_PATH" var conf
 
 echo "Export complete: $EXPORT_PATH"

--- a/snap/bin/export
+++ b/snap/bin/export
@@ -2,11 +2,11 @@
 set -e
 
 EXPORT_PATH="$SNAP_COMMON/export-$(date +%Y%m%d-%H%M%S).tar.gz"
+SOURCE_PATHS="$SNAP_COMMON/var $SNAP_COMMON/conf"
 
 echo "Exporting from: $SOURCE_PATHS"
 echo "Saving to: $EXPORT_PATH"
 
-cd "$SNAP_COMMON"
-tar -czf "$EXPORT_PATH" var conf
+tar -czf "$EXPORT_PATH" $SOURCE_PATHS
 
 echo "Export complete: $EXPORT_PATH"

--- a/snap/bin/import
+++ b/snap/bin/import
@@ -6,7 +6,7 @@ if [[ $# -ne 2 ]]; then
   exit 1
 fi
 
-TARBALL_PATH="$1"
+TARBALL_PATH="$2"
 
 if [[ ! -f "$TARBALL_PATH" ]]; then
   echo "Error: File not found: $TARBALL_PATH"

--- a/snap/bin/import
+++ b/snap/bin/import
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -ne 2 ]]; then
   echo "Usage: kalandra import <path-to-tarball>"
   exit 1
 fi

--- a/snap/bin/import
+++ b/snap/bin/import
@@ -16,6 +16,6 @@ fi
 echo "Importing tarball from: $TARBALL_PATH"
 
 # Extract with overwrite and preserve structure
-tar -xzf "$TARBALL_PATH" -C "$SNAP_COMMON" --overwrite
+tar -xzf "$TARBALL_PATH" -C "/" --overwrite
 
 echo "Import complete into: $SNAP_COMMON"

--- a/snap/bin/import
+++ b/snap/bin/import
@@ -16,6 +16,6 @@ fi
 echo "Importing tarball from: $TARBALL_PATH"
 
 # Extract with overwrite and preserve structure
-tar -xzf "$TARBALL_PATH" -C "$SNAP_COMMON"
+tar -xzf "$TARBALL_PATH" -C "$SNAP_COMMON" --overwrite
 
 echo "Import complete into: $SNAP_COMMON"

--- a/snap/bin/import
+++ b/snap/bin/import
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: kalandra import <path-to-tarball>"
+  exit 1
+fi
+
+TARBALL_PATH="$1"
+
+if [[ ! -f "$TARBALL_PATH" ]]; then
+  echo "Error: File not found: $TARBALL_PATH"
+  exit 2
+fi
+
+echo "Importing tarball from: $TARBALL_PATH"
+
+# Extract with overwrite and preserve structure
+tar -xzf "$TARBALL_PATH" -C "$SNAP_COMMON"
+
+echo "Import complete into: $SNAP_COMMON"

--- a/snap/bin/kalandra
+++ b/snap/bin/kalandra
@@ -4,6 +4,9 @@ case "$1" in
   export)
     exec "$SNAP/bin/export"
     ;;
+  import)
+    exec "$SNAP/bin/import"
+    ;;
   *)
     exec "$SNAP/bin/apt-mirror" "$@"
     ;;

--- a/snap/bin/kalandra
+++ b/snap/bin/kalandra
@@ -5,7 +5,7 @@ case "$1" in
     exec "$SNAP/bin/export"
     ;;
   import)
-    exec "$SNAP/bin/import"
+    exec "$SNAP/bin/import" "$@"
     ;;
   *)
     exec "$SNAP/bin/apt-mirror" "$@"

--- a/snap/bin/kalandra
+++ b/snap/bin/kalandra
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+case "$1" in
+  export)
+    exec "$SNAP/bin/export"
+    ;;
+  *)
+    exec "$SNAP/bin/apt-mirror" "$@"
+    ;;
+esac

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,9 +4,9 @@ APACHE_CONFIG="$SNAP_COMMON/conf/apache2.conf"
 mkdir -p "$SNAP_COMMON/conf"
 
 if [ ! -f "$MIRROR_CONFIG" ]; then
-    cp "$SNAP/snap/config/mirror.list" "$MIRROR_CONFIG"
+    cp "$SNAP/config/mirror.list" "$MIRROR_CONFIG"
 fi
 
 if [ ! -f "$APACHE_CONFIG" ]; then
-    cp "$SNAP/snap/config/apache2.conf" "$APACHE_CONFIG"
+    cp "$SNAP/config/apache2.conf" "$APACHE_CONFIG"
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,7 @@ parts:
     organize:
       start-apache: bin/start-apache
       export: bin/export
+      import: bin/import
   apache2-conf:
     plugin: dump
     source: snap/config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -41,6 +41,9 @@ parts:
   apache2-conf:
     plugin: dump
     source: snap/config
+    organize:
+      apache2.conf: config/apache2.conf
+      mirror.list: config/mirror.list
    
 layout:
   /etc/apt:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: strict
 
 apps:
   kalandra:
-    command: bin/apt-mirror
+    command: kalandra
     plugs:
       - network
   apache:
@@ -36,6 +36,7 @@ parts:
     source: snap/bin
     organize:
       start-apache: bin/start-apache
+      export: bin/export
   apache2-conf:
     plugin: dump
     source: snap/config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ summary: An apt-mirror2 wrapper with a built-in apache server
 description: |
   kalandra is a self-contained apt-mirror2/apache wrapper that can be used to spin up debian repository mirror.
   apt-mirror2 is a python port of apt-mirror, with additional features such a include_source_name to limit repository size.
-version: "0.1.0"
+version: "0.1.1"
 base: core24
 confinement: strict
 


### PR DESCRIPTION
kalandra import/export functionality to allow for easier porting to an offline env.

mirror.list tested:
```
set base_path         /var/spool/apt-mirror
set mirror_path       $base_path/mirror
set skel_path         $base_path/skel
set var_path          $base_path/var
set nthreads          8
set _tilde            0
deb [ arch=amd64 ] http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse
include_source_name http://archive.ubuntu.com/ubuntu wget
```

~200MB with meta files and the wget package directly.